### PR TITLE
Working pause and stop analysis buttons

### DIFF
--- a/src/app/angular/components/analysis/output/output.component.html
+++ b/src/app/angular/components/analysis/output/output.component.html
@@ -71,15 +71,15 @@
     <div class="d-flex justify-content-around pb-3">
       <button
         class="btn btn-outline-danger"
-        [disabled]="completeFiles === totalFiles"
+        [disabled]="!running"
         (click)="stopAnalysis()"
       >
         Stop Analysis
       </button>
       <button
         class="btn btn-outline-warning"
-        [disabled]="completeFiles === totalFiles"
-        (click)="pauseAnalysis()"
+        [disabled]="!running"
+        (click)="togglePause()"
       >
         {{ pause ? "Unpause Analysis" : "Pause Analysis" }}
       </button>

--- a/src/app/angular/components/analysis/output/output.component.ts
+++ b/src/app/angular/components/analysis/output/output.component.ts
@@ -50,15 +50,12 @@ export class OutputComponent implements OnInit {
     this.ap.cancelAnalysis();
   }
 
-  public pauseAnalysis(): void {
+  public togglePause(): void {
     if (this.ap.isPaused()) {
       this.ap.unpauseAnalysis();
-      this.runAnalysis();
       this.pause = false;
-      this.running = true;
     } else {
       this.ap.pauseAnalysis();
-      this.running = false;
       this.pause = true;
     }
   }
@@ -73,6 +70,7 @@ export class OutputComponent implements OnInit {
     this.completeFiles = 0;
     this.currentProgress = 0;
     this.running = true;
+    this.pause = false;
 
     this.ap.analyseFiles(items).subscribe(
       update => {
@@ -90,10 +88,12 @@ export class OutputComponent implements OnInit {
         console.error("Analysis Error: ", err);
         this.progressBarType = "danger";
         this.running = false;
+        this.pause = false;
         this.ref.detectChanges();
       },
       () => {
         this.running = false;
+        this.pause = false;
         this.ref.detectChanges();
       }
     );

--- a/src/app/electron/services/AP/ap.service.ts
+++ b/src/app/electron/services/AP/ap.service.ts
@@ -110,6 +110,7 @@ export class APService extends ElectronService {
     let paused = this.pause;
 
     if (this.analyses.length === 0 || this.cancel) {
+      this.analyses = [];
       APAnalysis.cleanupTemporaryFiles();
       this.subject.complete();
       return;

--- a/src/app/electron/services/AP/ap.service.ts
+++ b/src/app/electron/services/AP/ap.service.ts
@@ -16,14 +16,12 @@ import { FileSystemService } from "../file-system/file-system.service";
   providedIn: "root"
 })
 export class APService extends ElectronService {
-  /**
-   * Cancel analysis
-   */
+  private inProgress: boolean;
   private cancel: boolean;
-  /**
-   * Pause analysis
-   */
   private pause: boolean;
+  private subject: Subject<AnalysisProgress>;
+  private analyses: AnalysisItem[];
+  private fileNumber: number;
 
   constructor(private fileSystem: FileSystemService) {
     super();
@@ -58,6 +56,12 @@ export class APService extends ElectronService {
    */
   public unpauseAnalysis(): void {
     this.pause = false;
+
+    if (!this.inProgress && this.analyses.length !== 0) {
+      console.log("unPausing inProgress: ", this.inProgress);
+
+      this.recursiveAnalysis();
+    }
   }
 
   /**
@@ -76,20 +80,24 @@ export class APService extends ElectronService {
 
   /**
    * Analysis all files. Sends updates back to program through subject.
-   * @param analyses Analysis item list
+   * @param analysisItems Analysis item list
    */
-  public analyseFiles(analyses: AnalysisItem[]): Subject<AnalysisProgress> {
+  public analyseFiles(
+    analysisItems: AnalysisItem[]
+  ): Subject<AnalysisProgress> {
     this.pause = false;
     this.cancel = false;
-
-    const subject = new Subject<AnalysisProgress>();
+    this.inProgress = false;
+    this.subject = new Subject<AnalysisProgress>();
+    this.analyses = analysisItems;
+    this.fileNumber = 0;
 
     // Run analysis in separate thread
     setTimeout(() => {
-      this.recursiveAnalysis(subject, analyses);
+      this.recursiveAnalysis();
     }, 0);
 
-    return subject;
+    return this.subject;
   }
 
   /**
@@ -98,34 +106,43 @@ export class APService extends ElectronService {
    * @param analyses Analysis item list
    * @param fileNumber Number of file to analyse
    */
-  private recursiveAnalysis(
-    subject: Subject<AnalysisProgress>,
-    analyses: AnalysisItem[],
-    fileNumber = 0
-  ): void {
-    let paused: boolean = this.pause;
+  private recursiveAnalysis(): void {
+    let paused = this.pause;
 
-    if (analyses.length === 0 || paused || this.cancel) {
+    if (this.analyses.length === 0 || this.cancel) {
       APAnalysis.cleanupTemporaryFiles();
-      subject.complete();
+      this.subject.complete();
+      return;
+    }
+
+    // Don't run if paused
+    if (paused) {
       return;
     }
 
     // Loop over all analysis items
-    if (analyses.length > 0) {
-      const analysis = analyses.pop();
+    if (this.analyses.length > 0) {
+      this.inProgress = true;
+      console.log("inProgress: ", this.inProgress);
+      const analysis = this.analyses.pop();
       const terminal = analysis.spawn();
       let progress = 0;
 
-      subject.next({
+      this.subject.next({
         error: false,
         analysis,
         progress,
-        fileNumber
+        fileNumber: this.fileNumber
       });
 
       // Handle terminal output
       terminal.stdout.on("data", data => {
+        if (this.cancel) {
+          // Hard kill terminal
+          terminal.kill();
+          return;
+        }
+
         console.debug("Data: ", data.toString());
 
         paused = this.pause ? true : paused;
@@ -137,46 +154,50 @@ export class APService extends ElectronService {
           return;
         }
 
-        subject.next({
+        this.subject.next({
           error: false,
           analysis,
           progress,
-          fileNumber
+          fileNumber: this.fileNumber
         });
       });
 
       // Handle terminal error
       terminal.on("error", err => {
         console.debug("Error: ", err.toString());
-        fileNumber += 1;
+        this.fileNumber += 1;
+        this.inProgress = false;
+        console.log("inProgress: ", this.inProgress);
 
         paused = this.pause ? true : paused;
         progress = 100;
-        subject.next({
+        this.subject.next({
           error: true,
           errorDetails: err,
           analysis,
           progress,
-          fileNumber
+          fileNumber: this.fileNumber
         });
-        this.recursiveAnalysis(subject, analyses, fileNumber);
+        this.recursiveAnalysis();
       });
 
       // Handle terminal closing
       terminal.on("close", code => {
-        console.debug("Close: ", code.toString());
-        fileNumber += 1;
-
+        this.fileNumber += 1;
+        this.inProgress = false;
         paused = this.pause ? true : paused;
         progress = 100;
-        const error = code !== APTerminal.OK_CODE;
-        subject.next({
-          error,
+
+        console.debug("Code: ", code);
+
+        this.subject.next({
+          error: code ? code !== APTerminal.OK_CODE : false,
           analysis,
           progress,
-          fileNumber
+          fileNumber: this.fileNumber
         });
-        this.recursiveAnalysis(subject, analyses, fileNumber);
+
+        this.recursiveAnalysis();
       });
     }
   }


### PR DESCRIPTION
Added functionality to pause and stop analysis buttons.

Pause

- Pauses the next analysis and stops analyses
- Unpause resumes analyses
- If unpaused before analysis pauses, resumes analyses without issue

Cancel

- If analysis is running, kills the process
- Stops any new analyses from running
- Completes terminal subject

Closes #53 